### PR TITLE
fix(deps): bump gunicorn to 23.0.0 and requests to 2.33.1 (BF46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.6.2] - Unreleased (Security Hardening)
+
+EN
+### 🔒 Security
+* **BF46. Dependency CVE bumps** — `gunicorn` `21.2.0` → `23.0.0` and `requests` `2.31.0` → `2.33.1`. Clears five known advisories: two request-smuggling issues in Gunicorn (`PYSEC-2026-1433`, `PYSEC-2026-1434`, both fixed in 22.0.0) and three in Requests (`PYSEC-2026-1873`, `PYSEC-2026-1872`, `PYSEC-2026-2275`, the last only fixed in 2.33.0). No public API change in either package for the way MetaKavita uses them. `googletrans` is deliberately left at `4.0.0-rc1`.
+
+---
+
+FR
+### 🔒 Sécurité
+* **BF46. Montée de versions (CVE)** — `gunicorn` `21.2.0` → `23.0.0` et `requests` `2.31.0` → `2.33.1`. Corrige cinq vulnérabilités connues : deux failles de *request smuggling* dans Gunicorn (`PYSEC-2026-1433`, `PYSEC-2026-1434`, corrigées en 22.0.0) et trois dans Requests (`PYSEC-2026-1873`, `PYSEC-2026-1872`, `PYSEC-2026-2275`, cette dernière uniquement corrigée en 2.33.0). Aucun changement d'API publique pour l'usage qu'en fait MetaKavita. `googletrans` reste volontairement en `4.0.0-rc1`.
+
+---
+
 ## [1.6.1] - 2026-07-26 (Comic Flexible + Playful Stats + Batch QoS + Wikidata + Reliability)
 
 EN

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@
 ---
 
 ### ✨ Latest Releases (v1.5.6 to v1.6.1)
+- [x] **BF46. Dependency CVE bumps (unreleased):** `gunicorn` `21.2.0` → `23.0.0` (two request-smuggling advisories) and `requests` `2.31.0` → `2.33.1` (three advisories, the most recent only fixed in `2.33.0`). `googletrans` deliberately unchanged.
 - [x] **BDTheque.com comics provider (v1.6.1):** Provider `BDTHEQUE` for https://www.bdtheque.com/ (distinct from `BEDETHEQUE` / bedetheque.com). AJAX series search, series page scrape, Magic Input, unified scoring, covers.
 - [x] **MyAnimeList official API (v1.6.1):** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Replaces retired Jikan. Manga/Book, Magic Input, unified scoring.
 - [x] **Reliability barometer (v1.6.1):** Sidebar unlock + slider for match accept threshold (`0.30`–`1.00`, default `0.60`); `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD`; runtime via `get_match_accept_threshold()`.
@@ -150,6 +151,7 @@
 ---
 
 ### ✨ Dernières Nouveautés (v1.5.6 à v1.6.1)
+- [x] **BF46. Montée de versions CVE (non publié) :** `gunicorn` `21.2.0` → `23.0.0` (deux failles de *request smuggling*) et `requests` `2.31.0` → `2.33.1` (trois failles, la plus récente corrigée seulement en `2.33.0`). `googletrans` volontairement inchangé.
 - [x] **Provider BDTheque.com comics (v1.6.1) :** Provider `BDTHEQUE` pour https://www.bdtheque.com/ (distinct de `BEDETHEQUE` / bedetheque.com). Recherche AJAX, scrape fiche série, Magic Input, scoring unifié, covers.
 - [x] **MyAnimeList API officielle (v1.6.1) :** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Remplace Jikan. Manga/Book, Magic Input, scoring unifié.
 - [x] **Baromètre de fiabilité (v1.6.1) :** case + curseur sidebar pour le seuil d’acceptation (`0.30`–`1.00`, défaut `0.60`) ; `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD` ; runtime via `get_match_accept_threshold()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Flask==3.0.0
-requests==2.31.0
+requests==2.33.1
 Flask-SocketIO==5.3.6
 beautifulsoup4==4.12.3
 curl-cffi==0.6.2
-gunicorn==21.2.0
+gunicorn==23.0.0
 eventlet==0.35.2
 googletrans==4.0.0-rc1


### PR DESCRIPTION
First of the security PRs from #15. Targets `dev` as you asked.

Bumps the two dependencies with known advisories. Nothing else changes — no code, no behaviour.

| Package | From | To | Advisories cleared |
|---|---|---|---|
| `gunicorn` | `21.2.0` | `23.0.0` | `PYSEC-2026-1433`, `PYSEC-2026-1434` — request smuggling, both fixed in `22.0.0` |
| `requests` | `2.31.0` | `2.33.1` | `PYSEC-2026-1873` (fixed `2.32.0`), `PYSEC-2026-1872` (fixed `2.32.4`), `PYSEC-2026-2275` (fixed `2.33.0`) |

### Why these exact versions

**`requests` had to go past 2.32.** My original plan was `2.32.3`, but running `pip-audit` against the current pin showed three separate advisories, and the most recent one is only fixed in `2.33.0`. So `2.32.x` would have left the job half done. I stopped at `2.33.1` rather than the current `2.34.2` to keep the behavioural change to the scrapers as small as the fix allows — say the word if you'd rather be on latest.

**`gunicorn 23.0.0` rather than `22.0.0`.** `22.0.0` is enough to clear both advisories. `23.0.0` is the last release before the 24.x/25.x/26.x line and picks up a year of fixes at no compatibility cost that I can see — the `eventlet` worker class is still registered in `gunicorn.workers.SUPPORTED_WORKERS` on 23.0.0, so `--worker-class eventlet -w 1` is unaffected. Happy to drop to `22.0.0` if you'd prefer the absolute minimum change.

**`googletrans` untouched**, per your note in #15.

### Testing

- Full suite green: **232 passed, 0 failed** on Python 3.11.6, identical to the run against unmodified `dev` before the bump.
- `pip-audit` no longer reports either package.
- I could **not** boot Gunicorn locally to smoke-test it — Gunicorn doesn't import on Windows (`fcntl`), and I couldn't get a Linux container up on this machine. So the eventlet worker is verified as *registered*, not as *running*. Given you said you'd test on `dev` after merge, I didn't want to hold the PR for it, but flagging it honestly rather than claiming a test I didn't run.

### One thing to check before merging

I added a `## [1.6.2] - Unreleased (Security Hardening)` heading to `CHANGELOG.md` so this PR (and the three that follow) have somewhere to land. Be aware that `services/changelog_service.py::get_app_version()` reads the **first** `## [...]` in the file and uses it as the version shown in the UI title — so as it stands, the app will report `v1.6.2`. Rename that heading to whatever the release actually ends up being and it'll follow automatically.

The other three PRs (#non-root container, misc hardening, docs) each add a bullet under that same heading, so whichever merges first creates it and the rest will want a trivial rebase. Merge them in any order — ping me and I'll rebase the stragglers.

### Out of scope, but you should know

While checking the two packages above I ran `pip-audit` over the whole dependency tree. It reports advisories against `eventlet 0.35.2`, `flask 3.0.0` and `curl-cffi 0.6.2` as well, plus the transitive chain that `googletrans 4.0.0-rc1` drags in (`httpx 0.13.3`, `h11 0.9.0`, `h2 3.2.0`, `idna 2.10`) — that last group can't be fixed while `googletrans` stays, which you've already decided on, so it's an accepted risk rather than a bug.

I've deliberately **not** touched any of them here, because you scoped this PR to Gunicorn and Requests and I'd rather not surprise you mid-refactor. Want me to open a separate issue with the full audit output so you can triage it in your own time?
