### PR TITLE
fix(security): proxy-image size cap, webhook header token, config.json 0600 (BF47-BF49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [1.6.2] - Unreleased (Security Hardening)
+
+EN
+### 🔒 Security
+* **BF47. `/api/proxy-image` size cap** — The proxy now streams the remote response and refuses anything over **5 MB** with a `413`, instead of buffering the whole body into memory with `res.content`. An allowlisted host serving a very large file could previously exhaust the container's memory, which under `gunicorn -w 1` takes down the whole application. `Content-Length` is checked first as a cheap early reject; the running byte total is what actually enforces the limit, since that header can be absent or untrue. Redirect hops are now closed as they are followed (`url_allowlist.fetch_with_safe_redirects`), which matters once responses are streamed.
+* **BF48. Webhook token as a header** — `/webhook` accepts `X-Webhook-Token` in addition to the existing `?token=` query parameter, which keeps working unchanged. The header is preferred because a query string ends up in reverse-proxy access logs, browser history and `Referer` headers. Token comparison now runs on UTF-8 bytes, so a non-ASCII token returns a clean `401` instead of raising inside `secrets.compare_digest`.
+* **BF49. `config.json` written 0600** — `save_config()` restricts the file to its owner after every write. It holds `SECRET_KEY`, `WEBHOOK_TOKEN` and every API key, and was previously created with the process umask (0644 — world-readable — on a default Docker image). Applied on every save so a file restored from a backup or written by an older version is repaired too. Best-effort: `chmod` is skipped silently on Windows and on filesystems that refuse it, and can never fail a save.
+
+---
+
+FR
+### 🔒 Sécurité
+* **BF47. Plafond de taille sur `/api/proxy-image`** — Le proxy lit désormais la réponse distante en flux et refuse au-delà de **5 Mo** avec un `413`, au lieu de charger tout le corps en mémoire via `res.content`. Un hôte autorisé servant un très gros fichier pouvait épuiser la mémoire du conteneur — ce qui, sous `gunicorn -w 1`, emporte toute l'application. Le `Content-Length` sert de refus précoce peu coûteux ; c'est le total courant des octets lus qui applique réellement la limite, cet en-tête pouvant être absent ou mensonger. Les hops de redirection sont maintenant fermés au fil de leur suivi (`url_allowlist.fetch_with_safe_redirects`), ce qui compte dès lors que les réponses sont streamées.
+* **BF48. Jeton du webhook en en-tête** — `/webhook` accepte `X-Webhook-Token` en plus du paramètre `?token=` existant, qui continue de fonctionner à l'identique. L'en-tête est recommandé car une chaîne de requête se retrouve dans les logs d'accès des reverse proxies, l'historique du navigateur et les en-têtes `Referer`. La comparaison se fait désormais sur les octets UTF-8 : un jeton non-ASCII renvoie un `401` propre au lieu de faire lever `secrets.compare_digest`.
+* **BF49. `config.json` écrit en 0600** — `save_config()` restreint le fichier à son propriétaire après chaque écriture. Il contient `SECRET_KEY`, `WEBHOOK_TOKEN` et toutes les clés d'API, et était créé avec l'umask du processus (0644 — lisible par tous — sur une image Docker par défaut). Réappliqué à chaque sauvegarde, afin de corriger aussi un fichier restauré d'une sauvegarde ou écrit par une version antérieure. Best-effort : le `chmod` est ignoré silencieusement sous Windows et sur les systèmes de fichiers qui le refusent, et ne peut jamais faire échouer une sauvegarde.
+
+---
+
 ## [1.6.1] - 2026-07-26 (Comic Flexible + Playful Stats + Batch QoS + Wikidata + Reliability)
 
 EN

--- a/README.md
+++ b/README.md
@@ -268,7 +268,19 @@ Since Kavita does not natively provide outgoing Webhooks for library updates, Me
 
 #### 2. Webhook Endpoint for Custom Scripts & External Pipelines
 For advanced workflows (e.g., n8n, Node-RED, or custom download post-processing scripts), MetaKavita exposes a dedicated endpoint to trigger instant processing for a specific series:
+`POST http://<your-metakavita-ip>:5010/webhook`
+
+The token can be sent two ways. **Prefer the header** — a token in the query string gets written to reverse-proxy access logs, browser history and `Referer` headers, none of which are places a secret should live:
+
+```
+X-Webhook-Token: <YOUR_WEBHOOK_TOKEN>
+```
+
+The historical query form still works and is not deprecated, so existing integrations keep running untouched:
+
 `POST http://<your-metakavita-ip>:5010/webhook?token=<YOUR_WEBHOOK_TOKEN>`
+
+If both are supplied, the header wins.
 
 You can view your ready-to-use Webhook URL or generate a new token anytime directly inside the **Config Modal** (under the Planning section).
 
@@ -544,7 +556,19 @@ Comme Kavita ne propose pas nativement de Webhooks sortants lors des ajouts de b
 
 #### 2. Endpoint Webhook pour Scripts Tiers
 Pour les besoins d'automatisation avancés (ex: workflows n8n, Node-RED, ou scripts de post-traitement post-téléchargement), MetaKavita expose un endpoint dédié permettant de forcer l'enrichissement immédiat d'une série spécifique :
+`POST http://<ton-ip-metakavita>:5010/webhook`
+
+Le jeton peut être transmis de deux façons. **Privilégiez l'en-tête** : un jeton placé dans la chaîne de requête se retrouve dans les logs d'accès des reverse proxies, l'historique du navigateur et les en-têtes `Referer` — autant d'endroits où un secret n'a pas sa place :
+
+```
+X-Webhook-Token: <TON_WEBHOOK_TOKEN>
+```
+
+La forme historique en paramètre d'URL reste fonctionnelle et n'est pas dépréciée : les intégrations existantes continuent de marcher sans modification.
+
 `POST http://<ton-ip-metakavita>:5010/webhook?token=<TON_WEBHOOK_TOKEN>`
+
+Si les deux sont fournis, l'en-tête est prioritaire.
 
 Vous pouvez consulter votre URL Webhook prête à l'emploi ou régénérer un jeton à tout moment directement depuis la **Modal Config** (dans la section Planification).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@
 ---
 
 ### ✨ Latest Releases (v1.5.6 to v1.6.1)
+- [x] **BF47–BF49. Misc Hardening (unreleased, issue #15):** 5 MB streamed cap on `/api/proxy-image` (413 past the limit, redirect hops closed as followed); webhook accepts `X-Webhook-Token` with `?token=` kept working and byte-wise token comparison; `config.json` written 0600 on every save, best-effort.
 - [x] **BDTheque.com comics provider (v1.6.1):** Provider `BDTHEQUE` for https://www.bdtheque.com/ (distinct from `BEDETHEQUE` / bedetheque.com). AJAX series search, series page scrape, Magic Input, unified scoring, covers.
 - [x] **MyAnimeList official API (v1.6.1):** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Replaces retired Jikan. Manga/Book, Magic Input, unified scoring.
 - [x] **Reliability barometer (v1.6.1):** Sidebar unlock + slider for match accept threshold (`0.30`–`1.00`, default `0.60`); `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD`; runtime via `get_match_accept_threshold()`.
@@ -150,6 +151,7 @@
 ---
 
 ### ✨ Dernières Nouveautés (v1.5.6 à v1.6.1)
+- [x] **BF47–BF49. Durcissements divers (non publié, issue #15) :** plafond de 5 Mo en flux sur `/api/proxy-image` (413 au-delà, hops de redirection fermés au fil de l'eau) ; webhook acceptant `X-Webhook-Token` avec `?token=` conservé et comparaison du jeton en octets ; `config.json` écrit en 0600 à chaque sauvegarde, best-effort.
 - [x] **Provider BDTheque.com comics (v1.6.1) :** Provider `BDTHEQUE` pour https://www.bdtheque.com/ (distinct de `BEDETHEQUE` / bedetheque.com). Recherche AJAX, scrape fiche série, Magic Input, scoring unifié, covers.
 - [x] **MyAnimeList API officielle (v1.6.1) :** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Remplace Jikan. Manga/Book, Magic Input, scoring unifié.
 - [x] **Baromètre de fiabilité (v1.6.1) :** case + curseur sidebar pour le seuil d’acceptation (`0.30`–`1.00`, défaut `0.60`) ; `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD` ; runtime via `get_match_accept_threshold()`.

--- a/config_manager.py
+++ b/config_manager.py
@@ -347,3 +347,31 @@ def save_config(data):
             os.makedirs(DATA_DIR)
         with open(CONFIG_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
+
+        # Restrict the file to its owner (0600).
+        #
+        # config.json is the single most sensitive file the application owns: it holds
+        # SECRET_KEY (forging a session cookie is game over), WEBHOOK_TOKEN, the Kavita
+        # API key, and every translation-provider key. It is created with the process
+        # umask, which on a default Docker image means 0644 — world-readable. On a NAS
+        # this directory is usually a bind mount that other containers and other users
+        # can see, so "readable by anyone on the host" is a realistic exposure, not a
+        # theoretical one.
+        #
+        # Applied on every save rather than only at creation, because a file restored
+        # from a backup, copied from another host, or written by an older version will
+        # otherwise keep its permissive mode forever.
+        #
+        # Deliberately best-effort: chmod is a no-op on Windows and fails outright on
+        # some CIFS/SMB and FAT-backed bind mounts. Losing the hardening there is
+        # acceptable; losing the user's configuration because a chmod raised is not, so
+        # this must never be allowed to propagate.
+        try:
+            os.chmod(CONFIG_FILE, 0o600)
+        except OSError as chmod_err:
+            logging.debug(
+                "[Config] chmod 600 impossible sur %s (%s) — sans conséquence sur la "
+                "sauvegarde, mais les permissions du fichier restent celles du système "
+                "de fichiers.",
+                CONFIG_FILE, chmod_err,
+            )

--- a/routes/misc.py
+++ b/routes/misc.py
@@ -27,6 +27,28 @@ _SAFE_IMAGE_MIMES = frozenset({
     "image/avif",
 })
 
+# Hard ceiling on what the image proxy will hold in memory for a single request.
+#
+# Why this exists: the proxy is reachable by any logged-in user with any URL whose
+# host is in the scraper allowlist, and the response used to be read with
+# `res.content`, which buffers the ENTIRE body before anything else runs. A single
+# allowlisted host serving a multi-gigabyte file — compromised, misconfigured, or
+# just hosting something that is not a cover — was therefore enough to exhaust the
+# container's memory. That is especially damaging here because Gunicorn runs with
+# `-w 1` and the eventlet worker: there is one process for the whole application,
+# so one oversized fetch takes down every user's session, the batch queue and the
+# background sync workers with it.
+#
+# 5 MB is the value agreed on issue #15: HD covers realistically top out at 2-3 MB,
+# so this leaves headroom for a legitimately large cover while making the failure
+# mode a cheap 413 instead of an OOM kill.
+_MAX_PROXY_IMAGE_BYTES = 5 * 1024 * 1024
+
+# Read granularity for the streamed download. Small enough that the overshoot past
+# the cap is bounded by one chunk, large enough not to add meaningful syscall
+# overhead on a normal 2 MB cover.
+_PROXY_IMAGE_CHUNK_BYTES = 64 * 1024
+
 
 @misc_bp.route('/api/proxy-image')
 def proxy_image():
@@ -56,6 +78,10 @@ def proxy_image():
                 break
 
         # Redirects suivis uniquement si chaque hop reste dans l'allowlist (anti-SSRF CDN).
+        # `stream=True` keeps the body unread until we ask for it, which is what makes
+        # the size cap below possible: without it `requests` has already buffered the
+        # whole response by the time this call returns, and refusing it afterwards
+        # would be pointless.
         res, fetch_reason, final_url = fetch_with_safe_redirects(
             requests.get,
             img_url,
@@ -63,20 +89,66 @@ def proxy_image():
             max_hops=3,
             headers=headers,
             timeout=12,
+            stream=True,
         )
         if res is None:
             logging.warning("[Proxy] Fetch refusé (%s) : %s", fetch_reason, img_url)
             return "Redirect not allowed", 403
 
-        if res.status_code == 200:
-            raw_type = (res.headers.get('Content-Type') or 'image/jpeg').split(';')[0].strip().lower()
-            if raw_type not in _SAFE_IMAGE_MIMES and not raw_type.startswith('image/'):
-                logging.warning("[Proxy] Content-Type non image refusé (%s) pour %s", raw_type, final_url)
-                return "Unsupported media type", 415
-            mimetype = raw_type if raw_type.startswith('image/') else 'image/jpeg'
-            return send_file(io.BytesIO(res.content), mimetype=mimetype)
+        # Streaming responses hold a live connection until the body is consumed or the
+        # response is closed. Every exit path below therefore has to close it, so the
+        # whole block is wrapped rather than relying on garbage collection — under the
+        # single eventlet worker a leaked connection is a leaked greenthread.
+        try:
+            if res.status_code == 200:
+                raw_type = (res.headers.get('Content-Type') or 'image/jpeg').split(';')[0].strip().lower()
+                if raw_type not in _SAFE_IMAGE_MIMES and not raw_type.startswith('image/'):
+                    logging.warning("[Proxy] Content-Type non image refusé (%s) pour %s", raw_type, final_url)
+                    return "Unsupported media type", 415
+                mimetype = raw_type if raw_type.startswith('image/') else 'image/jpeg'
 
-        logging.warning("[Proxy] Échec HTTP %s pour : %s", res.status_code, final_url)
+                # Content-Length is only a hint: a hostile or simply misconfigured host
+                # can omit it, lie about it, or use chunked encoding where it does not
+                # exist at all. It is checked first purely to fail fast and avoid pulling
+                # megabytes we are going to throw away — the running total below is the
+                # check that actually enforces the limit.
+                declared_length = res.headers.get('Content-Length')
+                if declared_length is not None:
+                    try:
+                        if int(declared_length) > _MAX_PROXY_IMAGE_BYTES:
+                            logging.warning(
+                                "[Proxy] Image refusée : Content-Length %s > %s octets pour %s",
+                                declared_length, _MAX_PROXY_IMAGE_BYTES, final_url,
+                            )
+                            return "Image too large", 413
+                    except (TypeError, ValueError):
+                        # Unparseable header — ignore it and let the streaming check decide.
+                        pass
+
+                buffer = io.BytesIO()
+                downloaded = 0
+                for chunk in res.iter_content(chunk_size=_PROXY_IMAGE_CHUNK_BYTES):
+                    if not chunk:
+                        continue
+                    downloaded += len(chunk)
+                    if downloaded > _MAX_PROXY_IMAGE_BYTES:
+                        # Abandon mid-download. Overshoot is bounded by one chunk, so the
+                        # worst case held in memory is the cap plus 64 KB rather than
+                        # whatever the remote host felt like sending.
+                        logging.warning(
+                            "[Proxy] Image refusée : dépassement de %s octets en cours de "
+                            "téléchargement pour %s",
+                            _MAX_PROXY_IMAGE_BYTES, final_url,
+                        )
+                        return "Image too large", 413
+                    buffer.write(chunk)
+
+                buffer.seek(0)
+                return send_file(buffer, mimetype=mimetype)
+
+            logging.warning("[Proxy] Échec HTTP %s pour : %s", res.status_code, final_url)
+        finally:
+            res.close()
 
     except Exception as e:
         logging.warning("[Proxy] Erreur interne : %s", safe_exc_str(e))

--- a/routes/sync.py
+++ b/routes/sync.py
@@ -150,10 +150,39 @@ def export_errors():
 @sync_bp.route('/webhook', methods=['POST'])
 def webhook():
     config = load_config()
-    token = request.args.get('token')
     webhook_token = config.get('WEBHOOK_TOKEN', '')
 
-    if not token or not webhook_token or not secrets.compare_digest(token, webhook_token):
+    # The token may arrive either as the `X-Webhook-Token` header or as the historical
+    # `?token=` query parameter.
+    #
+    # The header is preferred and is what new integrations should use, because a query
+    # string is echoed into places a secret should never reach: reverse-proxy and web
+    # server access logs (nginx and Traefik both log the full request line by default),
+    # browser history, and `Referer` headers on any onward request. A header is not
+    # logged by default anywhere in that chain.
+    #
+    # The query form is deliberately kept working. Existing users have already pasted
+    # `?token=...` URLs into their Kavita webhook settings, and breaking those silently
+    # would stop their automation with no error they could see — so this is additive,
+    # and the header simply wins when both are present.
+    token = request.headers.get('X-Webhook-Token') or request.args.get('token')
+
+    # `secrets.compare_digest` raises TypeError on `str` arguments containing
+    # non-ASCII characters, so a token with an accent or an emoji in it would turn a
+    # failed authentication into an unhandled 500. Comparing the UTF-8 bytes avoids
+    # that entirely while keeping the constant-time property, and mirrors the same
+    # defensive pattern already used in routes/auth.py.
+    token_ok = False
+    if token and webhook_token:
+        try:
+            token_ok = secrets.compare_digest(
+                token.encode('utf-8'),
+                webhook_token.encode('utf-8'),
+            )
+        except (TypeError, ValueError):
+            token_ok = False
+
+    if not token_ok:
         logging.warning("🚨 [Sécurité] Tentative d'accès au webhook bloquée (Jeton invalide).")
         return jsonify(success=False, message="Unauthorized"), 401
 

--- a/tests/test_hardening_bf47_bf49.py
+++ b/tests/test_hardening_bf47_bf49.py
@@ -1,0 +1,375 @@
+"""
+Non-régression du lot de durcissement BF47–BF49 (issue #15).
+
+Three independent hardening changes, tested here together because they ship
+together:
+
+- **BF47** `/api/proxy-image` refuses anything over 5 MB, and refuses it while
+  streaming rather than after the whole body is already in memory.
+- **BF48** the webhook accepts its token from the `X-Webhook-Token` header, while
+  the historical `?token=` query form keeps working.
+- **BF49** `config.json` is written 0600.
+
+Comme le reste de la suite (voir tests/conftest.py), ces tests n'importent
+jamais `app.py` : celui-ci démarre des threads de fond et charge tous les
+scrapers à l'import. On enregistre donc uniquement le blueprint testé sur une
+app Flask ad hoc.
+"""
+import io
+import os
+import stat
+
+import pytest
+from flask import Flask
+
+from routes.misc import misc_bp, _MAX_PROXY_IMAGE_BYTES
+from routes.sync import sync_bp
+
+
+# --------------------------------------------------------------------------
+# Doubles de test
+# --------------------------------------------------------------------------
+
+class FakeStreamedResponse:
+    """Réponse `requests` minimale en mode `stream=True`.
+
+    Enregistre si `close()` a été appelée : le proxy tient une connexion ouverte
+    tant que le corps n'est pas lu, donc « la réponse est bien fermée sur CHAQUE
+    chemin de sortie » fait partie du contrat testé, pas d'un détail interne.
+    """
+
+    def __init__(self, *, status_code=200, headers=None, chunks=(), body=None):
+        self.status_code = status_code
+        self.headers = headers if headers is not None else {"Content-Type": "image/jpeg"}
+        self._chunks = list(chunks) if body is None else [body]
+        self.closed = False
+        self.consumed = 0
+
+    def iter_content(self, chunk_size=None):
+        for chunk in self._chunks:
+            self.consumed += len(chunk)
+            yield chunk
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def proxy_client(monkeypatch):
+    """App Flask ad hoc exposant `/api/proxy-image`, réseau et scrapers neutralisés."""
+    import routes.misc as misc
+
+    monkeypatch.setattr(
+        misc.ScraperRegistry, "get_all_proxy_domains", staticmethod(lambda: ["cdn.example"])
+    )
+    monkeypatch.setattr(misc.ScraperRegistry, "get_all", staticmethod(lambda: []))
+
+    test_app = Flask(__name__)
+    test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
+    test_app.register_blueprint(misc_bp)
+    return test_app.test_client()
+
+
+def _patch_fetch(monkeypatch, response):
+    """Remplace le fetch réseau du proxy par une réponse fabriquée."""
+    import routes.misc as misc
+
+    def fake_fetch(get_fn, url, allowed_domains, **kwargs):
+        fake_fetch.kwargs = kwargs
+        return response, "ok", url
+
+    fake_fetch.kwargs = {}
+    monkeypatch.setattr(misc, "fetch_with_safe_redirects", fake_fetch)
+    return fake_fetch
+
+
+# --------------------------------------------------------------------------
+# BF47 — plafond 5 Mo sur /api/proxy-image
+# --------------------------------------------------------------------------
+
+def test_proxy_image_serves_a_normal_cover(proxy_client, monkeypatch):
+    payload = b"\xff\xd8\xff" + b"x" * 2048
+    response = FakeStreamedResponse(body=payload)
+    _patch_fetch(monkeypatch, response)
+
+    res = proxy_client.get("/api/proxy-image?url=https://cdn.example/cover.jpg")
+
+    assert res.status_code == 200
+    assert res.data == payload
+    assert res.mimetype == "image/jpeg"
+    assert response.closed, "la réponse streamée doit être fermée après un succès"
+
+
+def test_proxy_image_rejects_oversized_content_length_without_downloading(
+    proxy_client, monkeypatch
+):
+    """Content-Length annoncé au-dessus du plafond : refus AVANT tout téléchargement.
+
+    C'est l'intérêt du contrôle en deux temps — quand l'hôte annonce honnêtement
+    une taille excessive, on n'a aucune raison de dépenser la bande passante.
+    """
+    response = FakeStreamedResponse(
+        headers={
+            "Content-Type": "image/jpeg",
+            "Content-Length": str(_MAX_PROXY_IMAGE_BYTES + 1),
+        },
+        chunks=[b"z" * 1024],
+    )
+    _patch_fetch(monkeypatch, response)
+
+    res = proxy_client.get("/api/proxy-image?url=https://cdn.example/huge.jpg")
+
+    assert res.status_code == 413
+    assert response.consumed == 0, "aucun octet ne doit être lu quand l'en-tête suffit à refuser"
+    assert response.closed
+
+
+def test_proxy_image_rejects_oversized_body_when_content_length_lies(
+    proxy_client, monkeypatch
+):
+    """Pas de Content-Length (ou mensonger) : c'est le total courant qui tranche.
+
+    Le cas qui compte vraiment : un hôte allowlisté compromis peut simplement
+    omettre l'en-tête, ou utiliser un encodage chunked où il n'existe pas. Le
+    plafond doit tenir sans lui.
+    """
+    oversized_chunks = [b"z" * (1024 * 1024)] * 8  # 8 Mo > 5 Mo
+    response = FakeStreamedResponse(
+        headers={"Content-Type": "image/png"}, chunks=oversized_chunks
+    )
+    _patch_fetch(monkeypatch, response)
+
+    res = proxy_client.get("/api/proxy-image?url=https://cdn.example/lying.png")
+
+    assert res.status_code == 413
+    # Le dépassement est borné par un chunk : on ne lit jamais les 8 Mo.
+    assert response.consumed <= _MAX_PROXY_IMAGE_BYTES + (1024 * 1024)
+    assert response.consumed < 8 * 1024 * 1024
+    assert response.closed
+
+
+def test_proxy_image_ignores_unparseable_content_length(proxy_client, monkeypatch):
+    """Un Content-Length illisible ne doit ni faire planter ni court-circuiter le plafond."""
+    payload = b"\x89PNG" + b"y" * 512
+    response = FakeStreamedResponse(
+        headers={"Content-Type": "image/png", "Content-Length": "not-a-number"},
+        body=payload,
+    )
+    _patch_fetch(monkeypatch, response)
+
+    res = proxy_client.get("/api/proxy-image?url=https://cdn.example/weird.png")
+
+    assert res.status_code == 200
+    assert res.data == payload
+    assert response.closed
+
+
+def test_proxy_image_requests_a_streaming_fetch(proxy_client, monkeypatch):
+    """`stream=True` est ce qui rend le plafond possible — le perdre le viderait de son sens.
+
+    Sans lui, `requests` a déjà bufferisé tout le corps au retour de l'appel, et
+    tout refus ultérieur arrive trop tard. D'où ce test explicite : une
+    régression silencieuse ici ne casserait aucun autre test.
+    """
+    fake_fetch = _patch_fetch(monkeypatch, FakeStreamedResponse(body=b"img"))
+
+    proxy_client.get("/api/proxy-image?url=https://cdn.example/a.jpg")
+
+    assert fake_fetch.kwargs.get("stream") is True
+
+
+def test_proxy_image_closes_response_on_non_image_content_type(proxy_client, monkeypatch):
+    response = FakeStreamedResponse(
+        headers={"Content-Type": "text/html"}, body=b"<html>nope</html>"
+    )
+    _patch_fetch(monkeypatch, response)
+
+    res = proxy_client.get("/api/proxy-image?url=https://cdn.example/page.html")
+
+    assert res.status_code == 415
+    assert response.closed
+
+
+def test_proxy_image_still_refuses_domains_outside_the_allowlist(proxy_client):
+    res = proxy_client.get("/api/proxy-image?url=https://evil.example/cover.jpg")
+    assert res.status_code == 403
+
+
+def test_safe_redirects_closes_each_intermediate_hop():
+    """Chaque hop de redirect doit être fermé avant de suivre le suivant.
+
+    Inoffensif tant que l'appelant ne streamait pas ; avec `stream=True` un hop
+    abandonné garde sa connexion ouverte — et sous le worker eventlet unique,
+    une greenthread avec elle.
+    """
+    from url_allowlist import fetch_with_safe_redirects
+
+    hop = FakeStreamedResponse(
+        status_code=302,
+        headers={"Location": "https://cdn.example/final.jpg"},
+    )
+    final = FakeStreamedResponse(body=b"img")
+    responses = [hop, final]
+
+    def fake_get(url, **kwargs):
+        return responses.pop(0)
+
+    res, reason, final_url = fetch_with_safe_redirects(
+        fake_get, "https://cdn.example/start.jpg", ["cdn.example"], stream=True
+    )
+
+    assert res is final
+    assert reason == "ok"
+    assert hop.closed, "le hop intermédiaire doit être fermé avant de suivre le redirect"
+    assert not final.closed, "la réponse finale appartient à l'appelant"
+
+
+# --------------------------------------------------------------------------
+# BF48 — jeton webhook en en-tête
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def webhook_client(monkeypatch):
+    """App Flask ad hoc exposant le blueprint `sync`, avec un WEBHOOK_TOKEN connu."""
+    import routes.sync as sync
+
+    monkeypatch.setattr(
+        sync, "load_config", lambda: {"WEBHOOK_TOKEN": "s3cret-token", "UI_LANG": "fr"}
+    )
+
+    test_app = Flask(__name__)
+    test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
+    test_app.register_blueprint(sync_bp)
+    return test_app.test_client()
+
+
+def test_webhook_accepts_the_header_token(webhook_client):
+    """400 (champs manquants) et non 401 : l'authentification est passée."""
+    res = webhook_client.post("/webhook", headers={"X-Webhook-Token": "s3cret-token"}, json={})
+    assert res.status_code == 400
+
+
+def test_webhook_still_accepts_the_legacy_query_token(webhook_client):
+    """Régression : les URLs `?token=` déjà collées dans Kavita doivent survivre."""
+    res = webhook_client.post("/webhook?token=s3cret-token", json={})
+    assert res.status_code == 400
+
+
+def test_webhook_rejects_a_wrong_header_token(webhook_client):
+    res = webhook_client.post("/webhook", headers={"X-Webhook-Token": "wrong"}, json={})
+    assert res.status_code == 401
+
+
+def test_webhook_rejects_a_wrong_query_token(webhook_client):
+    res = webhook_client.post("/webhook?token=wrong", json={})
+    assert res.status_code == 401
+
+
+def test_webhook_rejects_a_missing_token(webhook_client):
+    res = webhook_client.post("/webhook", json={})
+    assert res.status_code == 401
+
+
+def test_webhook_header_wins_over_the_query_parameter(webhook_client):
+    """En-tête prioritaire : un `?token=` périmé dans une URL enregistrée ne doit pas
+    invalider une intégration qui envoie correctement l'en-tête."""
+    res = webhook_client.post(
+        "/webhook?token=stale", headers={"X-Webhook-Token": "s3cret-token"}, json={}
+    )
+    assert res.status_code == 400
+
+
+def test_webhook_non_ascii_token_is_rejected_not_a_500(webhook_client):
+    """`secrets.compare_digest` lève TypeError sur des `str` non-ASCII.
+
+    Sans la comparaison en octets, un jeton accentué transformait un échec
+    d'authentification en 500 — et un 500 sur un chemin d'auth est une fuite
+    d'information autant qu'un bug.
+    """
+    res = webhook_client.post("/webhook", headers={"X-Webhook-Token": "mot-de-passé-é"}, json={})
+    assert res.status_code == 401
+
+
+def test_webhook_empty_configured_token_rejects_everything(monkeypatch):
+    """Fail closed : WEBHOOK_TOKEN vide ne doit jamais laisser passer un jeton vide."""
+    import routes.sync as sync
+
+    monkeypatch.setattr(sync, "load_config", lambda: {"WEBHOOK_TOKEN": "", "UI_LANG": "fr"})
+    test_app = Flask(__name__)
+    test_app.config.update(TESTING=True, SECRET_KEY="test-secret")
+    test_app.register_blueprint(sync_bp)
+    client = test_app.test_client()
+
+    assert client.post("/webhook", json={}).status_code == 401
+    assert client.post("/webhook?token=", json={}).status_code == 401
+    assert client.post("/webhook", headers={"X-Webhook-Token": ""}, json={}).status_code == 401
+
+
+# --------------------------------------------------------------------------
+# BF49 — permissions de config.json
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Redirige config_manager vers un config.json temporaire."""
+    import config_manager
+
+    monkeypatch.setattr(config_manager, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(config_manager, "CONFIG_FILE", str(tmp_path / "config.json"))
+    return config_manager
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows n'applique pas les bits de permission POSIX ; le chmod y est best-effort.",
+)
+def test_save_config_writes_the_file_0600(isolated_config):
+    isolated_config.save_config({"SECRET_KEY": "abc", "WEBHOOK_TOKEN": "def"})
+
+    mode = stat.S_IMODE(os.stat(isolated_config.CONFIG_FILE).st_mode)
+    assert mode == 0o600, f"attendu 0600, obtenu {oct(mode)}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="cf. ci-dessus")
+def test_save_config_repairs_permissions_of_an_existing_loose_file(isolated_config):
+    """Réappliqué à chaque sauvegarde, pas seulement à la création.
+
+    Un config.json restauré depuis une sauvegarde, copié depuis une autre machine
+    ou écrit par une version antérieure arrive en 0644 : sans réapplication il
+    garderait ce mode indéfiniment.
+    """
+    isolated_config.save_config({"SECRET_KEY": "abc"})
+    os.chmod(isolated_config.CONFIG_FILE, 0o644)
+
+    isolated_config.save_config({"SECRET_KEY": "abc", "KAVITA_API_KEY": "xyz"})
+
+    assert stat.S_IMODE(os.stat(isolated_config.CONFIG_FILE).st_mode) == 0o600
+
+
+def test_save_config_survives_a_chmod_failure(isolated_config, monkeypatch):
+    """Le durcissement ne doit jamais coûter la configuration de l'utilisateur.
+
+    chmod échoue sur certains montages CIFS/SMB et FAT. Perdre le durcissement y
+    est acceptable ; perdre la sauvegarde ne l'est pas.
+    """
+    def boom(*args, **kwargs):
+        raise OSError("Operation not permitted")
+
+    monkeypatch.setattr(os, "chmod", boom)
+
+    isolated_config.save_config({"SECRET_KEY": "abc", "WEBHOOK_TOKEN": "def"})
+
+    import json
+    with open(isolated_config.CONFIG_FILE, "r", encoding="utf-8") as f:
+        assert json.load(f)["WEBHOOK_TOKEN"] == "def"
+
+
+def test_save_config_still_writes_expected_content(isolated_config):
+    """Garde-fou : le durcissement ne change rien au contenu écrit."""
+    import json
+
+    payload = {"SECRET_KEY": "abc", "MAX_TAGS": 15, "SMART_SCORING": True}
+    isolated_config.save_config(payload)
+
+    with open(isolated_config.CONFIG_FILE, "r", encoding="utf-8") as f:
+        assert json.load(f) == payload

--- a/url_allowlist.py
+++ b/url_allowlist.py
@@ -119,6 +119,15 @@ def fetch_with_safe_redirects(
         if status in (301, 302, 303, 307, 308):
             headers = getattr(res, "headers", {}) or {}
             loc = headers.get("Location") or headers.get("location")
+            # The intermediate hop is finished with either way, so release it before
+            # moving on. This matters once a caller passes `stream=True` (the image
+            # proxy does, to enforce its size cap): a streaming response holds its
+            # connection open until the body is read or the response is closed, so
+            # abandoning one per redirect would leak a connection — and under the
+            # single-worker eventlet deployment, a greenthread with it.
+            closer = getattr(res, "close", None)
+            if callable(closer):
+                closer()
             if not loc:
                 return None, "Redirect sans Location", current
             current = urljoin(current, loc)


### PR DESCRIPTION
Third of the security PRs from #15 — the three small independent hardening items you approved. Targets `dev`.

Each is self-contained; if you want any one of them dropped, say so and I'll strip it without touching the other two.

---

### BF47 — `/api/proxy-image` 5 MB cap

The response was read with `res.content`, which buffers the **entire** body before any check can run. An allowlisted host serving a very large file — compromised, misconfigured, or just hosting something that isn't a cover — was enough to exhaust the container's memory. Under `gunicorn -w 1` with the eventlet worker that isn't one bad request, it's the whole application: every session, the batch queue and the background sync workers go with it.

Now streamed, with the cap enforced in two places for a reason worth spelling out:

- **`Content-Length`** is checked first, purely as a cheap early reject so we don't spend bandwidth on something we'll throw away. It is *not* the real check — a hostile host can omit it, understate it, or use chunked encoding where it doesn't exist.
- **A running byte total** during `iter_content` is what actually enforces the limit. Overshoot is bounded by one 64 KB chunk, so the worst case held in memory is 5 MB + 64 KB rather than whatever the remote host felt like sending.

Both refusals return `413`.

One knock-on change: `url_allowlist.fetch_with_safe_redirects` now closes each redirect hop as it follows it. That was harmless while every caller read the whole body eagerly, but a streamed response holds its connection open until the body is read or the response is closed — so abandoning one per redirect would leak a connection, and under the single eventlet worker, a greenthread with it.

### BF48 — webhook token as a header

`/webhook` now accepts `X-Webhook-Token`. **The `?token=` query form still works and is not deprecated** — users have already pasted those URLs into their Kavita settings, and breaking them would stop their automation with no error they'd ever see. The header simply wins if both are present.

The header is preferred because a query string is echoed into places a secret shouldn't reach: nginx and Traefik both log the full request line by default, plus browser history and `Referer` headers on any onward request.

While in there I also fixed a latent bug: `secrets.compare_digest` raises `TypeError` on `str` arguments containing non-ASCII, so a webhook token with an accent or an emoji in it turned a *failed authentication* into an unhandled 500. Comparison now runs on UTF-8 bytes, which keeps the constant-time property and mirrors the pattern already used in `routes/auth.py`.

Documented in both README language sections.

### BF49 — `config.json` written 0600

`save_config()` now restricts the file to its owner after every write. It holds `SECRET_KEY` (forging a session cookie with it is game over), `WEBHOOK_TOKEN`, the Kavita API key and every translation-provider key — and it was created with the process umask, which on a default Docker image is 0644, world-readable. On a NAS `data/` is usually a bind mount other containers and users can see, so that's a realistic exposure rather than a theoretical one.

Applied on **every** save, not just at creation, so a file restored from a backup or written by an older version gets repaired too.

Deliberately best-effort: `chmod` is a no-op on Windows and fails outright on some CIFS/SMB and FAT-backed bind mounts. It's wrapped in `try/except OSError` and logs at debug level. Losing the hardening on those filesystems is acceptable; losing someone's configuration because a `chmod` raised is not.

---

### Testing

New `tests/test_hardening_bf47_bf49.py` — 18 tests:

- proxy serves a normal cover unchanged; refuses an oversized `Content-Length` **without reading a single byte**; refuses an oversized body when `Content-Length` is absent or lying, and proves it stops early rather than reading all 8 MB; tolerates an unparseable `Content-Length`; still refuses non-allowlisted domains; closes the response on every exit path
- an explicit test that the fetch is made with `stream=True` — losing that would silently gut the cap without failing anything else
- redirect hops are closed as they're followed
- webhook: header accepted, legacy query accepted, wrong/missing token rejected, header beats query, non-ASCII token returns 401 rather than 500, and an empty configured `WEBHOOK_TOKEN` rejects everything including an empty submitted token
- config: file is 0600, a pre-existing 0644 file is repaired, a failing `chmod` doesn't lose the save, and content is unchanged

Run twice, since the permission assertions are meaningless on Windows:

- **Windows:** 250 passed, 2 skipped
- **Linux** (`python:3.11-slim`, matching your Dockerfile and CI): **252 passed, 0 skipped, 0 failed**

Baseline before this PR was 232 passed on both, so nothing regressed and the 0600 assertions really did execute rather than being quietly skipped.

One unrelated thing I noticed while running this: `tests/test_scraper_max_caps.py::test_enrichment_engine_caps_genres_and_tags_before_kavita` writes to the real `data/cache.db` instead of going through the `isolated_db` fixture — it failed for me the first time only because I'd mounted the source read-only. It passes normally and it's nothing to do with this PR, but you may want it isolated like the rest of the suite at some point. Happy to send a one-line fix separately if it's useful.

### Note on merge order

Like the other PRs in this batch, this adds a bullet under a new `## [1.6.2] - Unreleased` heading in `CHANGELOG.md`. Whichever of these merges first creates that heading and the rest will want a trivial rebase — merge in any order and ping me, I'll fix up the stragglers.

As agreed, I have **not** touched the `*_API_KEY` environment-variable persistence in this PR — that's the open question in my previous comment on #15.
