### PR TITLE
feat(docker): non-root container with PUID/PGID, healthcheck, dockerignore (C54-C55)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Build context exclusions.
+#
+# `COPY . .` in the Dockerfile copies whatever happens to be in the build context.
+# Without this file that includes anything .gitignore hides but that still exists
+# on the machine doing the build — and two of those are actively harmful:
+#
+#   data/    On any machine where the application has been run once, this holds a
+#            real config.json containing SECRET_KEY, WEBHOOK_TOKEN and every API
+#            key. Baked into an image layer they are readable by anyone who can
+#            pull that image, and deleting the file in a later layer would not
+#            remove it from history. The published ghcr.io images are not affected
+#            (CI builds from a clean checkout where data/ does not exist), but a
+#            local `docker build` is, and that is exactly how someone tests a
+#            change before pushing it.
+#
+#   .venv/   A local development virtualenv is easily 90 MB of Linux-incompatible
+#            or simply redundant packages, copied in and then shadowed by the real
+#            `pip install`. Pure image bloat.
+#
+# Everything else here is build speed and image size: a smaller context also means
+# fewer spurious cache invalidations on the COPY layer.
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+.github/
+
+# Runtime data — secrets live here (see above)
+data/
+
+# Local virtualenvs
+.venv/
+venv/
+env/
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Test suite and dev-only dependencies: not needed to run the application
+tests/
+pytest.ini
+requirements-dev.txt
+.pytest_cache/
+
+# README screenshots — displayed on GitHub, never served by the application
+assets/
+
+# Editor / OS noise
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# entrypoint.sh must keep LF endings in the working tree on every platform.
+#
+# It is copied into the image and executed by /bin/sh. If a clone made on Windows
+# converts it to CRLF, the shebang becomes "#!/bin/sh\r" and the container dies at
+# startup with an unhelpful "no such file or directory" — a failure that only ever
+# reproduces for contributors building on Windows, which makes it disproportionately
+# annoying to diagnose.
+#
+# Scoped to this one file rather than `*.sh` on purpose: debug/download_wikidata_dump.sh
+# is currently stored with CRLF endings, and a blanket rule would silently rewrite it
+# the next time anyone renormalized the tree.
+/entrypoint.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.6.2] - Unreleased (Security Hardening)
+
+EN
+### 🔒 Security
+* **C54. Non-root container with PUID/PGID** — The image no longer runs as root. It ships a dedicated `metakavita` user defaulting to **1000:1000**, and a linuxserver.io-style entrypoint applies `PUID`/`PGID` at *runtime* before dropping privileges with `gosu`, so a bind-mounted `./data` owned by any uid keeps working. Gunicorn still runs as PID 1, so `docker stop` reaches it directly and shuts down cleanly. **Upgrading:** an existing `data/` is root-owned from previous versions — the entrypoint takes ownership of it automatically on every start, including sideloaded scrapers under `data/scrapers/`. A `HEALTHCHECK` is included; it only asserts the server answers HTTP, deliberately tolerating redirects so it stays valid once authentication is enforced.
+* **C55. `.dockerignore` added** — `COPY . .` previously copied whatever was in the build context. On any machine where the application had been run, that included `data/config.json` with a live `SECRET_KEY`, `WEBHOOK_TOKEN` and API keys, baked into an image layer. Published `ghcr.io` images were never affected (CI builds from a clean checkout), but local builds were. Also drops local virtualenvs, `.git/` and the test suite from the image — 268 MB → 185 MB.
+
+---
+
+FR
+### 🔒 Sécurité
+* **C54. Conteneur non-root avec PUID/PGID** — L'image ne tourne plus en root. Elle embarque un utilisateur dédié `metakavita` par défaut en **1000:1000**, et un entrypoint façon linuxserver.io applique `PUID`/`PGID` au *démarrage* avant d'abandonner les privilèges via `gosu` : un `./data` monté et possédé par n'importe quel uid continue donc de fonctionner. Gunicorn reste PID 1, donc `docker stop` l'atteint directement et l'arrêt est propre. **Mise à jour :** un `data/` existant appartient à root depuis les versions précédentes — l'entrypoint en reprend la propriété automatiquement à chaque démarrage, y compris les scrapers sideloadés dans `data/scrapers/`. Un `HEALTHCHECK` est fourni ; il vérifie uniquement que le serveur répond en HTTP, en tolérant volontairement les redirections pour rester valable une fois l'authentification en place.
+* **C55. Ajout d'un `.dockerignore`** — `COPY . .` copiait auparavant tout le contenu du contexte de build. Sur une machine où l'application avait déjà tourné, cela incluait `data/config.json` avec un `SECRET_KEY`, un `WEBHOOK_TOKEN` et des clés d'API réels, figés dans une couche d'image. Les images publiées sur `ghcr.io` n'ont jamais été concernées (la CI build depuis un checkout propre), mais les builds locaux l'étaient. Exclut aussi les virtualenvs locaux, `.git/` et la suite de tests — 268 Mo → 185 Mo.
+
+---
+
 ## [1.6.1] - 2026-07-26 (Comic Flexible + Playful Stats + Batch QoS + Wikidata + Reliability)
 
 EN

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,49 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# gosu drops privileges in the entrypoint once the runtime PUID/PGID fixup is
+# done. It is preferred over `su`/`sudo` because it execs the target process
+# directly instead of forking: the application keeps PID 1, so `docker stop`
+# delivers SIGTERM to gunicorn itself and the shutdown is clean.
+#
+# The 1000:1000 default matches the first non-system account on virtually every
+# desktop Linux and NAS, so the common case needs no PUID/PGID at all.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1000 metakavita \
+    && useradd -u 1000 -g 1000 -M -d /app -s /usr/sbin/nologin metakavita
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+# Set the bit here rather than relying on the checked-out file mode: a clone made
+# on Windows does not preserve the executable bit, and the build would otherwise
+# fail only for contributors on that platform.
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 EXPOSE 5010
+
+# Liveness only — is the WSGI server accepting and answering HTTP at all.
+#
+# Deliberately tolerant of the response *code*. Every route in the application
+# either redirects to the login page or is POST-only, and once the authentication
+# work lands (issue #15) that will be true unconditionally. A check demanding 200
+# would therefore start reporting a perfectly healthy container as unhealthy the
+# moment a password is set. Any answer below 500 proves the process is alive,
+# eventlet is looping and Flask is routing, which is what a healthcheck is for.
+#
+# Uses the interpreter already in the image instead of adding curl or wget, which
+# would mean another package in the final layer purely for this.
+# `http.client` is used rather than urllib because it does not raise on 4xx/5xx,
+# which keeps this a single expression: the status is inspected directly, and any
+# genuine failure (connection refused, timeout) raises and exits non-zero anyway.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import http.client,sys; c=http.client.HTTPConnection('127.0.0.1',5010,timeout=4); c.request('GET','/login'); sys.exit(0 if c.getresponse().status < 500 else 1)"
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["gunicorn", "--worker-class", "eventlet", "-w", "1", "--bind", "0.0.0.0:5010", "app:app"]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ services:
       - "5010:5010"
     environment:
       - ADMIN_PASSWORD=your_secure_password
+      # - PUID=1000    # Host user id that should own ./data (run `id -u`)
+      # - PGID=1000    # Host group id that should own ./data (run `id -g`)
       # - ROOT_PATH=/metakavita # Optional subpath for reverse proxies
       # - CORS_ALLOWED_ORIGINS=https://metakavita.home.local.ltd # Explicit HTTPS origins for Socket.IO / AJAX
       # - MAX_TAGS=15    # Power-user: max tags written to Kavita (1–100)
@@ -199,6 +201,7 @@ docker compose up -d --build
 | Variable | Description | Default Value |
 | :--- | :--- | :--- |
 | `ADMIN_PASSWORD` | Secures the dashboard with a password. | *(Empty = No Auth)* |
+| `PUID` / `PGID` | User and group id the application runs as, and which owns everything under `/app/data`. Set these to the owner of your bind-mounted `./data` folder (`id -u` / `id -g`) if it is not `1000:1000`. The container starts as root only long enough to apply them, then drops privileges. | `1000` / `1000` |
 | `ROOT_PATH` | Custom URL subpath when hosted behind a reverse proxy (e.g. `/metakavita`). | *(Empty)* |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated explicit origins allowed for CORS (HTTP + Socket.IO), e.g. `https://metakavita.home.local.ltd`. Empty = Same-Origin only. `*` is rejected. Does not replace proper reverse-proxy WebSocket upgrade config. | *(Empty)* |
 | `KAVITA_URL` | Kavita URL used by MetaKavita for API calls (can be an internal Docker hostname, e.g. `http://kavita:5000`). | *(Empty)* |
@@ -448,6 +451,8 @@ services:
       - "5010:5010"
     environment:
       - ADMIN_PASSWORD=votre_mot_de_passe_securise
+      # - PUID=1000    # UID hôte qui doit posséder ./data (`id -u`)
+      # - PGID=1000    # GID hôte qui doit posséder ./data (`id -g`)
       # - ROOT_PATH=/metakavita # Optionnel : pour hébergement en sous-dossier
       # - CORS_ALLOWED_ORIGINS=https://metakavita.home.local.ltd # Origins HTTPS explicites pour Socket.IO / AJAX
       # - MAX_TAGS=15    # Power-user : max tags écrits dans Kavita (1–100)
@@ -475,6 +480,7 @@ docker compose up -d --build
 | Variable | Description | Valeur par défaut |
 | :--- | :--- | :--- |
 | `ADMIN_PASSWORD` | Sécurise l'interface par mot de passe. | *(Vide = Pas d'Auth)* |
+| `PUID` / `PGID` | UID et GID sous lesquels tourne l'application, et propriétaires de tout le contenu de `/app/data`. À renseigner avec le propriétaire de votre dossier `./data` monté (`id -u` / `id -g`) s'il n'est pas `1000:1000`. Le conteneur ne démarre en root que le temps de les appliquer, puis abandonne ses privilèges. | `1000` / `1000` |
 | `ROOT_PATH` | Sous-chemin d'URL lors de l'exposition derrière un reverse proxy (ex: `/metakavita`). | *(Vide)* |
 | `CORS_ALLOWED_ORIGINS` | Origins CORS explicites séparées par des virgules (HTTP + Socket.IO), ex: `https://metakavita.home.local.ltd`. Vide = Same-Origin uniquement. `*` est rejeté. Ne remplace pas une config reverse-proxy correcte pour l'upgrade WebSocket. | *(Vide)* |
 | `KAVITA_URL` | URL Kavita utilisée par MetaKavita pour les appels API (peut être un hostname Docker interne, ex: `http://kavita:5000`). | *(Vide)* |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,8 @@
 ---
 
 ### ✨ Latest Releases (v1.5.6 to v1.6.1)
+- [x] **C54. Non-root Container with PUID/PGID (unreleased, issue #15):** Dedicated `metakavita` user (default 1000:1000); linuxserver.io-style entrypoint applies `PUID`/`PGID` at runtime, takes ownership of `/app/data` (existing root-owned installs repaired automatically), then drops privileges with `gosu`. Gunicorn stays PID 1 for clean `docker stop`. `HEALTHCHECK` added, tolerant of redirects so it survives the upcoming auth gate.
+- [x] **C55. `.dockerignore` (unreleased, issue #15):** Stops `COPY . .` baking a local `data/config.json` — live `SECRET_KEY`, `WEBHOOK_TOKEN`, API keys — into image layers on local builds (published ghcr images unaffected). Also drops virtualenvs, `.git/` and tests: 268 MB → 185 MB.
 - [x] **BDTheque.com comics provider (v1.6.1):** Provider `BDTHEQUE` for https://www.bdtheque.com/ (distinct from `BEDETHEQUE` / bedetheque.com). AJAX series search, series page scrape, Magic Input, unified scoring, covers.
 - [x] **MyAnimeList official API (v1.6.1):** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Replaces retired Jikan. Manga/Book, Magic Input, unified scoring.
 - [x] **Reliability barometer (v1.6.1):** Sidebar unlock + slider for match accept threshold (`0.30`–`1.00`, default `0.60`); `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD`; runtime via `get_match_accept_threshold()`.
@@ -150,6 +152,8 @@
 ---
 
 ### ✨ Dernières Nouveautés (v1.5.6 à v1.6.1)
+- [x] **C54. Conteneur non-root avec PUID/PGID (non publié, issue #15) :** utilisateur dédié `metakavita` (défaut 1000:1000) ; entrypoint façon linuxserver.io appliquant `PUID`/`PGID` au démarrage, reprenant la propriété de `/app/data` (installations root existantes réparées automatiquement), puis abandon des privilèges via `gosu`. Gunicorn reste PID 1 pour un `docker stop` propre. `HEALTHCHECK` ajouté, tolérant aux redirections pour survivre au futur gate d'authentification.
+- [x] **C55. `.dockerignore` (non publié, issue #15) :** empêche `COPY . .` de figer un `data/config.json` local — `SECRET_KEY`, `WEBHOOK_TOKEN` et clés d'API réels — dans les couches de l'image lors des builds locaux (images ghcr publiées non concernées). Exclut aussi les virtualenvs, `.git/` et les tests : 268 Mo → 185 Mo.
 - [x] **Provider BDTheque.com comics (v1.6.1) :** Provider `BDTHEQUE` pour https://www.bdtheque.com/ (distinct de `BEDETHEQUE` / bedetheque.com). Recherche AJAX, scrape fiche série, Magic Input, scoring unifié, covers.
 - [x] **MyAnimeList API officielle (v1.6.1) :** Provider `MAL` via API v2 + `X-MAL-CLIENT-ID` (`MAL_API_KEY` = Client ID). Remplace Jikan. Manga/Book, Magic Input, scoring unifié.
 - [x] **Baromètre de fiabilité (v1.6.1) :** case + curseur sidebar pour le seuil d’acceptation (`0.30`–`1.00`, défaut `0.60`) ; `MATCH_THRESHOLD_CUSTOM` / `MATCH_ACCEPT_THRESHOLD` ; runtime via `get_match_accept_threshold()`.

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -8,10 +8,21 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      # --- Permissions du dossier data / data folder ownership ---
+      # Le conteneur tourne en utilisateur non-root (1000:1000 par défaut).
+      # Si votre dossier ./data appartient à un autre utilisateur, renseignez
+      # votre UID/GID (`id -u` / `id -g`) — sinon, laissez commenté.
+      #
+      # The container runs as a non-root user (1000:1000 by default). If your
+      # ./data folder is owned by a different user, set your own UID/GID here
+      # (`id -u` / `id -g`) — otherwise leave commented out.
+      # - PUID=1000
+      # - PGID=1000
+
       # --- Variables Optionnelles / Optional Variables ---
       # Toutes ces valeurs peuvent être configurées plus tard, directement depuis l'interface Web.
       # All these values can be configured later directly from the Web UI.
-      
+
       # - KAVITA_URL=http://ton-kavita:5001
       # - KAVITA_API_KEY=ta_cle_api_kavita
       # - DEEPL_API_KEY=ta_cle_api_deepl

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# MetaKavita container entrypoint — linuxserver.io-style PUID/PGID handling.
+#
+# The image ships a dedicated unprivileged user (metakavita, 1000:1000) rather
+# than running the application as root. That alone would be enough for security,
+# but it is not enough for a self-hoster: the ./data bind mount is a directory on
+# THEIR filesystem, owned by THEIR uid, and a container user with a fixed uid of
+# 1000 will simply be unable to write to it whenever their account is 1001, or
+# 1026 on a Synology, or anything else.
+#
+# So the uid/gid are decided at RUNTIME from PUID/PGID rather than baked in at
+# build time. That is the whole reason this script exists: a Dockerfile USER
+# directive is static, and a static uid is what breaks people's permissions.
+#
+# The script runs as root and does exactly three things before giving that up:
+#   1. move the metakavita user/group to the requested uid/gid,
+#   2. take ownership of the paths the application writes to,
+#   3. drop to the unprivileged user with gosu and exec the real command.
+#
+# `exec` matters: gunicorn replaces this shell as PID 1, so it receives SIGTERM
+# from `docker stop` directly and shuts down cleanly instead of being killed
+# after the timeout.
+set -e
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+APP_USER=metakavita
+APP_GROUP=metakavita
+DATA_DIR=/app/data
+
+# If the container was started with `--user` (or `user:` in compose), we are
+# already unprivileged and none of the fixup below is possible — usermod and
+# chown both need root. That is a legitimate way to run this image for someone
+# who manages ownership themselves, so honour it instead of failing: skip
+# straight to the command.
+if [ "$(id -u)" != "0" ]; then
+    echo "[entrypoint] Running as uid $(id -u) (not root) — skipping PUID/PGID setup."
+    # The application creates data/ relative to its working directory, so it only
+    # needs the directory to be writable. Warn rather than exit: the user chose
+    # this mode and may well have set the ownership correctly on the host.
+    if [ ! -w "$DATA_DIR" ] && [ -e "$DATA_DIR" ]; then
+        echo "[entrypoint] WARNING: $DATA_DIR is not writable by uid $(id -u)."
+    fi
+    exec "$@"
+fi
+
+# Reassign the group first, then the user. `-o` permits a non-unique id, which is
+# needed because the requested uid may already belong to another account inside
+# the image (uid 1000 is 'ubuntu' or similar on some bases).
+if [ "$PGID" != "$(id -g $APP_USER)" ]; then
+    groupmod -o -g "$PGID" "$APP_GROUP"
+fi
+if [ "$PUID" != "$(id -u $APP_USER)" ]; then
+    usermod -o -u "$PUID" "$APP_USER"
+fi
+
+echo "[entrypoint] Starting MetaKavita as ${APP_USER} (uid $(id -u $APP_USER), gid $(id -g $APP_USER))."
+
+# Create the data directory before dropping privileges. The application does
+# `os.makedirs("data")` itself, but by then it is unprivileged and /app is
+# root-owned, so it would fail on a first run with no bind mount.
+mkdir -p "$DATA_DIR"
+
+# Take ownership of everything the application writes: config.json, cache.db,
+# metakavita.log, and any sideloaded scraper under data/scrapers/.
+#
+# This is also the upgrade path. Anyone running a previous version was running it
+# as root, so their existing bind-mounted data/ is full of root-owned files that
+# the new unprivileged process could not otherwise open. Doing it on every start
+# rather than only when the directory looks wrong keeps that repair automatic and
+# idempotent — and cheap, since data/ holds a handful of small files.
+chown -R "$PUID:$PGID" "$DATA_DIR"
+
+exec gosu "$APP_USER" "$@"


### PR DESCRIPTION
Second of the security PRs from #15 — the non-root container with PUID/PGID you asked for. Targets `dev`.

### C54 — non-root with runtime PUID/PGID

The image ships a dedicated `metakavita` user defaulting to **1000:1000**.

The uid/gid are applied at **runtime** rather than baked in with a `USER` directive, and that's the whole reason `entrypoint.sh` exists. A static uid is exactly what breaks self-hosters: `./data` is a directory on *their* filesystem owned by *their* account, which is `1001` as often as `1000`, and something else entirely on a Synology. So the entrypoint runs as root just long enough to move the user to `PUID`/`PGID`, take ownership of `/app/data`, and drop privileges.

`gosu` rather than `su`/`sudo` because it execs the target process instead of forking — gunicorn keeps PID 1, so `docker stop` delivers SIGTERM to it directly.

**On upgrading:** anyone running a previous version was running it as root, so their existing bind-mounted `data/` is full of root-owned files the new unprivileged process couldn't otherwise open. The entrypoint chowns it on every start, so the repair is automatic — no action needed from users, but worth a line in the release notes.

**Healthcheck:** included, but it only asserts that the server answers HTTP, tolerating any status below 500. It can't demand `200`, because every route either redirects to the login page or is POST-only — and once the auth work lands that's unconditional, so a stricter check would start reporting healthy containers as unhealthy the moment someone sets a password. If you're happy with the `/healthz` endpoint I asked about in my last comment on #15, this becomes a stricter and simpler check; until then this is the honest version. It uses the bundled Python rather than adding `curl` to the final layer.

### C55 — `.dockerignore` (a finding, and a scope call I'd like you to sanity-check)

This one wasn't in the original review — I hit it while testing the image and think it matters.

`COPY . .` copies whatever is in the build context. `.gitignore` has no bearing on that. So on any machine where the application has been run once, the build was copying in **`data/config.json` — with a live `SECRET_KEY`, `WEBHOOK_TOKEN` and API keys — and writing it into an image layer**, where deleting it in a later step wouldn't remove it from the image's history. I confirmed it on my own build before adding the file:

```
$ docker run --rm --entrypoint sh <image> -c "python -c \"import json;d=json.load(open('/app/data/config.json'));print('SECRET_KEY present:', bool(d.get('SECRET_KEY')))\""
SECRET_KEY present: True
```

**Your published `ghcr.io` images are not affected** — `docker-publish.yml` builds from a clean checkout where `data/` doesn't exist, and I checked that before writing this. The exposure is local `docker build`, which is precisely how someone tests a change before pushing it, and how anyone following the "Build from Source" path in the README runs the app.

It also drops local virtualenvs, `.git/` and the test suite from the image: **268 MB → 185 MB**.

I've kept `CHANGELOG.md` in the image deliberately — `changelog_service.py` reads it at runtime for the version string and the changelog modal — and verified it's still there after the change.

I know you scoped this PR to the non-root container and this is one file beyond that. My reasoning for including it rather than raising it separately: without it, the artifact *this PR produces* is wrong, so it felt like part of getting the container right rather than a separate idea. Say the word and I'll pull it into its own PR.

### Testing

Built the image and ran it. Every scenario below was executed, not reasoned about:

| Scenario | Result |
|---|---|
| Defaults, no `PUID`/`PGID` | gunicorn master runs as **uid 1000**, is **PID 1**, `data/` owned `1000:1000`, `GET /login` → 302 |
| `PUID=1042 PGID=1043` | master runs as **1042:1043**, `data/` chowned to match, app writes successfully |
| **Upgrade path** — seeded a root-owned `data/` with a real `config.json`, `cache.db` and a sideloaded `data/scrapers/custom.py` | all three chowned to `1042:1043`, container healthy, **pre-existing `SECRET_KEY` preserved** |
| `docker run --user 1500:1500` | entrypoint detects it can't do the fixup, logs it, and execs the command rather than dying |
| `HEALTHCHECK` | reports `healthy` |
| `docker stop` | completes in **~1s**, master logs a clean shutdown — SIGTERM is reaching PID 1, not a 10s timeout kill |

`pytest` still 232 passed (this PR changes no Python).

Note that CI won't cover any of this — `docker-publish.yml` only triggers on push to `main`/`dev`, not on pull requests, so the Dockerfile isn't built by the PR checks. That's why I tested it by hand rather than leaning on the green tick.

### Two small things while I was in there

- `.gitattributes` pins `entrypoint.sh` to LF. A CRLF shebang (`#!/bin/sh\r`) makes the container die with a misleading "no such file or directory", and it only ever reproduces for contributors on Windows. I scoped the rule to that one file rather than `*.sh` on purpose — see below.
- **Unrelated observation, not touched:** `debug/download_wikidata_dump.sh` is currently stored in the repo *with* CRLF endings, which would make it fail to run on Linux as-is. That's why the `.gitattributes` rule isn't a blanket `*.sh` — a broad rule would silently rewrite that file the next time anyone renormalized the tree. Worth a separate look at some point; I've deliberately left it alone.

### Merge order

Like the others in this batch, this adds bullets under a new `## [1.6.2] - Unreleased` heading in `CHANGELOG.md`. Whichever merges first creates it and the rest want a trivial rebase — merge in any order and ping me.
